### PR TITLE
remove referenced object from AbstractSubsRef

### DIFF
--- a/ae-subs-generator/src/main/java/uk/ac/ebi/subs/submissiongeneration/AeMageTabConverter.java
+++ b/ae-subs-generator/src/main/java/uk/ac/ebi/subs/submissiongeneration/AeMageTabConverter.java
@@ -79,8 +79,8 @@ public class AeMageTabConverter {
         for (Protocol p : protocols){
             p.setDomain(submission.getDomain());
             ProtocolRef pr = (ProtocolRef)p.asRef();
-            pr.setReferencedObject(p);
             study.getProtocolRefs().add(pr);
+            submission.getProtocols().add(p);
         }
 
 

--- a/subs-aeagent/src/main/java/uk/ac/ebi/subs/arrayexpress/agent/ArrayExpressSubmissionProcessor.java
+++ b/subs-aeagent/src/main/java/uk/ac/ebi/subs/arrayexpress/agent/ArrayExpressSubmissionProcessor.java
@@ -52,8 +52,6 @@ public class ArrayExpressSubmissionProcessor {
         logger.info("received updated samples for submission {}",updatedSamplesEnvelope.getSubmissionId());
 
         Map<String,Sample> samplesByAccession = new HashMap<>();
-
-
         updatedSamplesEnvelope.getUpdatedSamples().forEach(s -> samplesByAccession.put(s.getAccession(),s));
 
         String[] updatedSampleAccessions = new String[0];
@@ -64,16 +62,18 @@ public class ArrayExpressSubmissionProcessor {
         logger.debug("found {} sdrs for sample update for submission {}",sdrs.size(),updatedSamplesEnvelope.getSubmissionId());
 
         for(SampleDataRelationship sdr : sdrs){
-            for (SampleUse sampleUse : sdr.getSampleUses()){
-                if (sampleUse.getSampleRef() == null || sampleUse.getSampleRef().getAccession() == null) continue;
+            ListIterator<Sample> sampleListIterator = sdr.getSamples().listIterator();
 
-                String sampleAccession = sampleUse.getSampleRef().getAccession();
+            while (sampleListIterator.hasNext()){
+                Sample s = sampleListIterator.next();
 
-                if (samplesByAccession.containsKey(sampleAccession)){
-                    sampleUse.getSampleRef().setReferencedObject(samplesByAccession.get(sampleAccession));
-                    logger.debug("update sample {} in sdr {} ",sampleAccession,sdr.getId());
+                if (samplesByAccession.containsKey(s.getAccession())){
+                    sampleListIterator.remove();
+                    sampleListIterator.add(samplesByAccession.get(s.getAccession()));
+                    logger.debug("update sample {} in sdr {} ",s.getAccession(),sdr.getId());
                 }
             }
+
         }
 
         sampleDataRelatioshipRepository.save(sdrs);
@@ -163,11 +163,12 @@ public class ArrayExpressSubmissionProcessor {
 
         //find sample
         for (SampleUse su : assay.getSampleUses()){
-            su.getSampleRef().fillIn(submission.getSamples(),submissionEnvelope.getSupportingSamples());
+            Sample s = su.getSampleRef().fillIn(submission.getSamples(),submissionEnvelope.getSupportingSamples());
 
-            if (su.getSampleRef().getReferencedObject() == null){
+            if (s == null){
                 throw new RuntimeException("No sample found for "+su.getSampleRef());
             }
+            sdr.getSamples().add(s);
         }
         //TODO change sdr to take a list?
 

--- a/subs-aeagent/src/main/java/uk/ac/ebi/subs/arrayexpress/model/SampleDataRelationship.java
+++ b/subs-aeagent/src/main/java/uk/ac/ebi/subs/arrayexpress/model/SampleDataRelationship.java
@@ -7,7 +7,9 @@ import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import uk.ac.ebi.subs.data.component.SampleUse;
 import uk.ac.ebi.subs.data.submittable.Assay;
 import uk.ac.ebi.subs.data.submittable.AssayData;
+import uk.ac.ebi.subs.data.submittable.Sample;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @CompoundIndexes({
@@ -18,8 +20,9 @@ public class SampleDataRelationship {
     String id;
 
     Assay assay;
-    List<SampleUse> sampleUses;
-    List<AssayData> assayData;
+    List<SampleUse> sampleUses = new ArrayList<>();
+    List<AssayData> assayData = new ArrayList<>();
+    List<Sample> samples = new ArrayList<>();
 
     public String getId() {
         return id;
@@ -51,5 +54,13 @@ public class SampleDataRelationship {
 
     public void setAssayData(List<AssayData> assayData) {
         this.assayData = assayData;
+    }
+
+    public List<Sample> getSamples() {
+        return samples;
+    }
+
+    public void setSamples(List<Sample> samples) {
+        this.samples = samples;
     }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/AnalysisRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/AnalysisRef.java
@@ -4,15 +4,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.Analysis;
 
 public class AnalysisRef extends AbstractSubsRef<Analysis> {
-    Analysis referencedObject;
 
-    @Override
-    public Analysis getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(Analysis referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/AssayDataRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/AssayDataRef.java
@@ -3,16 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.AssayData;
 
 public class AssayDataRef extends AbstractSubsRef<AssayData> {
-    AssayData referencedObject;
-
-    @Override
-    public AssayData getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(AssayData referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/AssayRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/AssayRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.Assay;
 
 public class AssayRef extends AbstractSubsRef<Assay> {
-    Assay referencedObject;
 
-    @Override
-    public Assay getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(Assay referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/EgaDacPolicyRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/EgaDacPolicyRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.EgaDacPolicy;
 
 public class EgaDacPolicyRef extends AbstractSubsRef<EgaDacPolicy> {
-    EgaDacPolicy referencedObject;
 
-    @Override
-    public EgaDacPolicy getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(EgaDacPolicy referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/EgaDacRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/EgaDacRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.EgaDac;
 
 public class EgaDacRef  extends AbstractSubsRef<EgaDac> {
-    EgaDac referencedObject;
 
-    @Override
-    public EgaDac getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(EgaDac referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/EgaDatasetRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/EgaDatasetRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.EgaDataset;
 
 public class EgaDatasetRef extends AbstractSubsRef<EgaDataset>{
-    EgaDataset referencedObject;
 
-    @Override
-    public EgaDataset getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(EgaDataset referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/ProjectRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/ProjectRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.Project;
 
 public class ProjectRef  extends AbstractSubsRef<Project> {
-    Project referencedObject;
 
-    @Override
-    public Project getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(Project referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/ProtocolRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/ProtocolRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.Protocol;
 
 public class ProtocolRef extends AbstractSubsRef<Protocol> {
-    Protocol referencedObject;
 
-    @Override
-    public Protocol getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(Protocol referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleGroupRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleGroupRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.SampleGroup;
 
 public class SampleGroupRef extends AbstractSubsRef<SampleGroup> {
-    SampleGroup referencedObject;
 
-    @Override
-    public SampleGroup getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(SampleGroup referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.Sample;
 
 public class SampleRef  extends AbstractSubsRef<Sample> {
-    Sample referencedObject;
 
-    @Override
-    public Sample getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(Sample referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/StudyRef.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/StudyRef.java
@@ -3,15 +3,5 @@ package uk.ac.ebi.subs.data.component;
 import uk.ac.ebi.subs.data.submittable.Study;
 
 public class StudyRef  extends AbstractSubsRef<Study>{
-    Study referencedObject;
 
-    @Override
-    public Study getReferencedObject() {
-        return referencedObject;
-    }
-
-    @Override
-    public void setReferencedObject(Study referencedObject) {
-        this.referencedObject = referencedObject;
-    }
 }

--- a/subs-data-model/src/test/java/uk/ac/ebi/subs/data/component/SubsRefTest.java
+++ b/subs-data-model/src/test/java/uk/ac/ebi/subs/data/component/SubsRefTest.java
@@ -16,6 +16,7 @@ public class SubsRefTest {
 
     ProjectRef subsLink;
     List<Project> candidates;
+    Project match;
 
 
     @Test
@@ -24,8 +25,8 @@ public class SubsRefTest {
 
         run();
 
-        assertThat("subs ref filled in", subsLink.getReferencedObject(), notNullValue());
-        assertThat("subs link ref", subsLink.getReferencedObject(), equalTo(candidates.get(0)));
+        assertThat("subs ref filled in", match, notNullValue());
+        assertThat("subs link ref", match, equalTo(candidates.get(0)));
     };
 
     @Test
@@ -34,8 +35,8 @@ public class SubsRefTest {
 
         run();
 
-        assertThat("subs link accession", subsLink.getAccession(), nullValue());
-        assertThat("subs link ref", subsLink.getReferencedObject(), equalTo(candidates.get(0)));
+        assertThat("subs link accession", match, notNullValue());
+        assertThat("subs link ref", match, equalTo(candidates.get(0)));
     };
 
 
@@ -45,7 +46,7 @@ public class SubsRefTest {
 
         run();
 
-        assertThat("subs ref filled in", subsLink.getReferencedObject(), nullValue());
+        assertThat("subs ref filled in", match, nullValue());
     }
 
     @Test
@@ -64,6 +65,8 @@ public class SubsRefTest {
         subsLink.setArchive(Archive.Usi.name());
         subsLink.setAlias("unclebob");
         subsLink.setDomain("testDomain");
+
+        match = null;
     };
 
     private Project addCandidate(String alias){
@@ -79,7 +82,7 @@ public class SubsRefTest {
 
 
     private void run(){
-        subsLink.fillIn(candidates);
+        match = subsLink.findMatch(candidates);
     }
 
 }

--- a/subs-enaagent/src/main/java/uk/ac/ebi/subs/enaagent/EnaAgentSubmissionsProcessor.java
+++ b/subs-enaagent/src/main/java/uk/ac/ebi/subs/enaagent/EnaAgentSubmissionsProcessor.java
@@ -125,9 +125,11 @@ public class EnaAgentSubmissionsProcessor {
 
         for (SampleUse su : assay.getSampleUses()){
             SampleRef sr = su.getSampleRef();
-            sr.fillIn(submission.getSamples(),submissionEnvelope.getSupportingSamples());
+            Sample sample = sr.fillIn(submission.getSamples(),submissionEnvelope.getSupportingSamples());
 
-            if (sr.getReferencedObject() != null) enaSampleRepository.save(sr.getReferencedObject());
+            if (sample != null) {
+                enaSampleRepository.save(sample);
+            }
         }
 
 


### PR DESCRIPTION
See pull request from Adam Faulconbridge and comment from David Richardson
https://github.com/EMBL-EBI-SUBS/subs/pull/21/commits/5a1a4dace48f2e005794d0beb3ae2a430fca0069

Removed the referenced object field from abstract subs ref and child classes and fix whatever broke. Users weren't expected to supply the referenced object, so the design was unnecessarily confusing.