### PR TITLE
SampleRelationship fixed [SUBS-379]

### DIFF
--- a/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleRelationship.java
+++ b/subs-data-model/src/main/java/uk/ac/ebi/subs/data/component/SampleRelationship.java
@@ -3,13 +3,11 @@ package uk.ac.ebi.subs.data.component;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import uk.ac.ebi.subs.data.submittable.Sample;
 
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class SampleRelationship extends SampleRef {
     private String relationshipNature; // e.g. Child of
-    private String targetAccession;
 
     public String getRelationshipNature() {
         return relationshipNature;
@@ -19,11 +17,4 @@ public class SampleRelationship extends SampleRef {
         this.relationshipNature = relationshipNature;
     }
 
-    public String getTargetAccession() {
-        return targetAccession;
-    }
-
-    public void setTargetAccession(String targetAccession) {
-        this.targetAccession = targetAccession;
-    }
 }

--- a/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/BsdRelationshipToUsiRelationship.java
+++ b/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/BsdRelationshipToUsiRelationship.java
@@ -15,8 +15,7 @@ public class BsdRelationshipToUsiRelationship implements Converter<Relationship,
     @Override
     public SampleRelationship convert(Relationship bsdRelationship) {
         SampleRelationship usiRelationship = new SampleRelationship();
-        usiRelationship.setAccession(bsdRelationship.getSource());
-        usiRelationship.setTargetAccession(bsdRelationship.getTarget());
+        usiRelationship.setAccession(bsdRelationship.getTarget());
         usiRelationship.setRelationshipNature(bsdRelationship.getType());
         return usiRelationship;
     }

--- a/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/UsiRelationshipToBsdRelationship.java
+++ b/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/UsiRelationshipToBsdRelationship.java
@@ -12,9 +12,7 @@ import java.util.TreeSet;
 @Service
 public class UsiRelationshipToBsdRelationship {
 
-    private String sourceAccession;
-
-    private Relationship convert(SampleRelationship usiRelationship) {
+    private Relationship convert(String sourceAccession, SampleRelationship usiRelationship) {
         Relationship bsdRelationship = null;
         if(usiRelationship != null) {
             bsdRelationship = Relationship.build(
@@ -27,13 +25,13 @@ public class UsiRelationshipToBsdRelationship {
     }
 
     public Set<Relationship> convert(Sample usiSample) {
-        sourceAccession = usiSample.getAccession();
+        String sourceAccession = usiSample.getAccession();
         List<SampleRelationship> sampleRelationships = usiSample.getSampleRelationships();
 
         Set<Relationship> relationshipSet = new TreeSet<>();
         if(sampleRelationships != null) {
             for(SampleRelationship usiRelationship : sampleRelationships) {
-                relationshipSet.add(convert(usiRelationship));
+                relationshipSet.add(convert(sourceAccession, usiRelationship));
             }
         }
         return relationshipSet;

--- a/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/UsiRelationshipToBsdRelationship.java
+++ b/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/UsiRelationshipToBsdRelationship.java
@@ -1,31 +1,35 @@
 package uk.ac.ebi.subs.agent.converters;
 
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Service;
 import uk.ac.ebi.biosamples.model.Relationship;
 import uk.ac.ebi.subs.data.component.SampleRelationship;
+import uk.ac.ebi.subs.data.submittable.Sample;
 
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
 @Service
-public class UsiRelationshipToBsdRelationship implements Converter<SampleRelationship, Relationship> {
+public class UsiRelationshipToBsdRelationship {
 
-    @Override
-    public Relationship convert(SampleRelationship usiRelationship) {
+    private String sourceAccession;
+
+    private Relationship convert(SampleRelationship usiRelationship) {
         Relationship bsdRelationship = null;
         if(usiRelationship != null) {
             bsdRelationship = Relationship.build(
-                    usiRelationship.getAccession(),            // source (itself)
-                    usiRelationship.getRelationshipNature(),   // type
-                    usiRelationship.getTargetAccession()       // target
+                    sourceAccession,                            // source
+                    usiRelationship.getRelationshipNature(),    // type
+                    usiRelationship.getAccession()              // target
             );
         }
         return bsdRelationship;
     }
 
-    public Set<Relationship> convert(List<SampleRelationship> sampleRelationships) {
+    public Set<Relationship> convert(Sample usiSample) {
+        sourceAccession = usiSample.getAccession();
+        List<SampleRelationship> sampleRelationships = usiSample.getSampleRelationships();
+
         Set<Relationship> relationshipSet = new TreeSet<>();
         if(sampleRelationships != null) {
             for(SampleRelationship usiRelationship : sampleRelationships) {
@@ -34,4 +38,5 @@ public class UsiRelationshipToBsdRelationship implements Converter<SampleRelatio
         }
         return relationshipSet;
     }
+
 }

--- a/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/UsiSampleToBsdSample.java
+++ b/subs-samples-agent/src/main/java/uk/ac/ebi/subs/agent/converters/UsiSampleToBsdSample.java
@@ -10,15 +10,10 @@ import uk.ac.ebi.biosamples.model.Attribute;
 import uk.ac.ebi.biosamples.model.ExternalReference;
 import uk.ac.ebi.biosamples.model.Sample;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeSet;
 
 @Service
@@ -78,12 +73,12 @@ public class UsiSampleToBsdSample implements Converter<uk.ac.ebi.subs.data.submi
         // Archive for samples is BioSamples
 
         Sample bioSample = Sample.build(
-                usiSample.getAlias(),                                           // name
-                usiSample.getAccession(),                                       // accession
-                release,                                                        // release date
-                update,                                                         // update date
-                attributeSet,                                                   // attributes
-                toBsdRelationship.convert(usiSample.getSampleRelationships()),  // relationships
+                usiSample.getAlias(),                   // name
+                usiSample.getAccession(),               // accession
+                release,                                // release date
+                update,                                 // update date
+                attributeSet,                           // attributes
+                toBsdRelationship.convert(usiSample),   // relationships
                 externalRefs
         );
 

--- a/subs-samples-agent/src/test/java/uk/ac/ebi/subs/agent/converters/RelationshipConverterTest.java
+++ b/subs-samples-agent/src/test/java/uk/ac/ebi/subs/agent/converters/RelationshipConverterTest.java
@@ -11,6 +11,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.ac.ebi.biosamples.model.Relationship;
 import uk.ac.ebi.subs.agent.utils.TestUtils;
 import uk.ac.ebi.subs.data.component.SampleRelationship;
+import uk.ac.ebi.subs.data.submittable.Sample;
+
+import java.util.Arrays;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {
@@ -31,16 +34,21 @@ public class RelationshipConverterTest {
 
     private SampleRelationship usiRelationship;
     private Relationship bsdRelationship;
+    private Sample sample;
 
     @Before
     public void setUp() {
         usiRelationship = utils.generateUsiRelationship();
         bsdRelationship = utils.generateBsdRelationship();
+
+        sample = new Sample();
+        sample.setAccession("SAM910");
+        sample.setSampleRelationships(Arrays.asList(usiRelationship));
     }
 
     @Test
     public void convertFromUsiRelationship() {
-        Relationship conversion = toBsdRelationship.convert(usiRelationship);
+        Relationship conversion = toBsdRelationship.convert(sample).iterator().next();
         SampleRelationship conversionBack = toUsiRelationship.convert(conversion);
         Assert.assertEquals(usiRelationship, conversionBack);
     }
@@ -48,7 +56,12 @@ public class RelationshipConverterTest {
     @Test
     public void convertFromBsdRelationship() {
         SampleRelationship conversion = toUsiRelationship.convert(bsdRelationship);
-        Relationship conversionBack = toBsdRelationship.convert(conversion);
+
+        Sample sample = new Sample();
+        sample.setAccession("SAM123");
+        sample.setSampleRelationships(Arrays.asList(conversion));
+
+        Relationship conversionBack = toBsdRelationship.convert(sample).iterator().next();
         Assert.assertEquals(bsdRelationship, conversionBack);
     }
 

--- a/subs-samples-agent/src/test/java/uk/ac/ebi/subs/agent/utils/TestUtils.java
+++ b/subs-samples-agent/src/test/java/uk/ac/ebi/subs/agent/utils/TestUtils.java
@@ -146,7 +146,6 @@ public class TestUtils {
         SampleRelationship usiRelationship = new SampleRelationship();
         usiRelationship.setRelationshipNature("Child of");
         usiRelationship.setAccession("SAM990");
-        usiRelationship.setTargetAccession("SAM678");
         return usiRelationship;
     }
 
@@ -187,9 +186,9 @@ public class TestUtils {
 
     public Relationship generateBsdRelationship() {
         Relationship bsdRelationship = Relationship.build(
-                "Child of", // type
-                "SAM456",  // target
-                "SAM123"   // source
+                "SAM123",
+                "Chilf of",
+                "SAM456"
         );
         return bsdRelationship;
     }


### PR DESCRIPTION
USI `SampleRelationship` is now using the `Sample.accession` as the **source** accession and the `SampleRelationship.accession` as the **target** for the BioSamples relationship.
