### PR TITLE
gradle deployJar task depends on assembly so that it doesn't run the …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ subprojects {
         }
     }
 
-    task deployJar(type: SshTask, dependsOn: 'build') {
+    task deployJar(type: SshTask, dependsOn: 'assemble') {
         doLast {
             def deployHome = "/data/" + project.name;
             File jarDeployDir = new File(deployHome,"jar")


### PR DESCRIPTION
deployJar depends on assemble , jenkins runs the externalCiTest first