### PR TITLE
redefine indexes for submittable

### DIFF
--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Analysis.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Analysis.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 //@Document //TODO - there is a potential cyclic reference that is flagged up when you have @Document - reconsider design
 public class Analysis extends uk.ac.ebi.subs.data.submittable.Analysis implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Analysis.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Analysis.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 //@Document //TODO - there is a potential cyclic reference that is flagged up when you have @Document - reconsider design
 public class Analysis extends uk.ac.ebi.subs.data.submittable.Analysis implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Assay.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Assay.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class Assay extends uk.ac.ebi.subs.data.submittable.Assay implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Assay.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Assay.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class Assay extends uk.ac.ebi.subs.data.submittable.Assay implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/AssayData.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/AssayData.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1 }")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1 }")
 })
 @Document
 public class AssayData extends uk.ac.ebi.subs.data.submittable.AssayData implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/AssayData.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/AssayData.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1 }")
 })
 @Document
 public class AssayData extends uk.ac.ebi.subs.data.submittable.AssayData implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDac.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDac.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class EgaDac extends uk.ac.ebi.subs.data.submittable.EgaDac implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDac.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDac.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class EgaDac extends uk.ac.ebi.subs.data.submittable.EgaDac implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDacPolicy.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDacPolicy.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class EgaDacPolicy extends uk.ac.ebi.subs.data.submittable.EgaDacPolicy implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDacPolicy.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDacPolicy.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class EgaDacPolicy extends uk.ac.ebi.subs.data.submittable.EgaDacPolicy implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDataset.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDataset.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class EgaDataset extends uk.ac.ebi.subs.data.submittable.EgaDataset implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDataset.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/EgaDataset.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class EgaDataset extends uk.ac.ebi.subs.data.submittable.EgaDataset implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Project.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Project.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class Project extends uk.ac.ebi.subs.data.submittable.Project implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Project.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Project.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class Project extends uk.ac.ebi.subs.data.submittable.Project implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Protocol.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Protocol.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class Protocol extends uk.ac.ebi.subs.data.submittable.Protocol implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Protocol.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Protocol.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class Protocol extends uk.ac.ebi.subs.data.submittable.Protocol implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Sample.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Sample.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class Sample extends uk.ac.ebi.subs.data.submittable.Sample implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Sample.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Sample.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class Sample extends uk.ac.ebi.subs.data.submittable.Sample implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/SampleGroup.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/SampleGroup.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class SampleGroup extends uk.ac.ebi.subs.data.submittable.SampleGroup implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/SampleGroup.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/SampleGroup.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class SampleGroup extends uk.ac.ebi.subs.data.submittable.SampleGroup implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Study.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Study.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId_status", def = "{ 'submission.$id': 1, 'status': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
 })
 @Document
 public class Study extends uk.ac.ebi.subs.data.submittable.Study implements StoredSubmittable {

--- a/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Study.java
+++ b/subs-repository/src/main/java/uk/ac/ebi/subs/repository/model/Study.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @CompoundIndexes({
         @CompoundIndex(name = "team_alias", def = "{ 'team.name': 1, 'alias': 1 }"),
         @CompoundIndex(name = "accession", def = "{ 'accession': 1}"),
-        @CompoundIndex(name = "submissionId", def = "{ 'submission.$id': 1}")
+        @CompoundIndex(name = "submissionId", def = "{ 'submission.id': 1}")
 })
 @Document
 public class Study extends uk.ac.ebi.subs.data.submittable.Study implements StoredSubmittable {


### PR DESCRIPTION
StoredSubmittables all had index definitions that included status, which is no longer part of these classes. Index changed to just use submission.id 